### PR TITLE
Agregando archivo flujo.txt y rotateImages.py

### DIFF
--- a/flujo.txt
+++ b/flujo.txt
@@ -1,0 +1,17 @@
+Resumen de comandos en terminal:
+
+-Una vez tomadas las fotos con el chdkptp, se rotan con el siguiente comando (se deben tener las imagenes en la misma carpeta que el archivo rotateImages.py):
+
+$python rotateImages.py
+
+-Después aplicamos el scantailor a todas las imagenes de la carpeta rotated:
+
+$scantailor-cli -l=1.5 --threshold=4 --margins-top=2.5 --margins-right=2.5 --margins-bottom=2.5 --margins-left=2.5 *.jpg ./
+
+-Ahora aplicamos el tesseract a todos los .tif:
+
+$parallel tesseract -l spa {} {.} hocr ::: *.tif
+
+-Por ultimo generamos un pdf con pdfbeads:
+
+$pdfbeads *.tif > out.pdf

--- a/rotateImages.py
+++ b/rotateImages.py
@@ -1,0 +1,50 @@
+import logging
+import shutil
+import pyexiv2
+import os
+from wand.image import Image
+
+#Funcion reutilizada de autorotate.py de spreads para rotar las imagenes una vez tomadas con chdkptp.
+def autorotate_image(in_path, out_path):
+	try:
+		metadata = pyexiv2.ImageMetadata(in_path)
+		metadata.read()
+		
+		orient = int(metadata['Exif.Image.Orientation'].value)
+		print metadata
+		print orient
+	except:
+		return
+
+	img = Image(filename=in_path)
+	if orient == 1:
+		shutil.copyfile(in_path, out_path)
+		return
+	elif orient == 2:
+		img.flip()
+	elif orient == 3:
+		img.rotate(180)
+	elif orient == 4:
+		img.flop()
+	elif orient == 5:
+		img.rotate(90)
+		img.flip()
+	elif orient == 6:
+		img.rotate(90)
+	elif orient == 7:
+		img.rotate(270)
+		img.flip()
+	elif orient == 8:
+		img.rotate(270)
+	img.save(filename=out_path)
+
+
+#Rota todas las imagenes del directorio actual y las coloca en una carpeta creada llamada rotated.
+def rotateImages():
+    path = os.getcwd()
+    for fn in os.listdir(path):
+        if fn != 'rotateImages.py':
+            autorotate_image(fn,'rotated/'+os.path.splitext(fn)[0]+"_rotated.jpg")
+
+
+rotateImages()


### PR DESCRIPTION
El archivo flujo.txt tiene un resumen de los comandos en terminal para posprocesar las fotos tomadas con chdkptp y generar un pdf, el rotateImages es un script en python para rotar todas las imagenes de un directorio
