### PR TITLE
Fixing freezing problem when running the Chdkptp service on Raspberry Pi

### DIFF
--- a/src/services/cameraService.py
+++ b/src/services/cameraService.py
@@ -1,6 +1,6 @@
 from model.camera import Camera
 from services.utils.chdkptp import Chdkptp
-import multiprocessing
+from threading import Thread
 
 
 class CameraService:
@@ -17,7 +17,7 @@ class CameraService:
         jobs = []
         for cam in self.cams:
             CameraService.pic_number += 1
-            process = multiprocessing.Process(target=Chdkptp.shoot, args=(cam, save_path+str(CameraService.pic_number)))
+            process = Thread(target=Chdkptp.shoot, args=(cam, save_path+str(CameraService.pic_number)))
             jobs.append(process)
             process.start()
 


### PR DESCRIPTION
The troubleshoot was to change the module for managing the threads. Multiprocessing.Process seemed to have a bad performance on the Raspberry
so change it for Threading Thread and improved significantly.